### PR TITLE
Add dev requirements poetry install

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -37,6 +37,10 @@ inputs:
   poetry-version:
     description: 'Version of poetry. Latest if not specified.'
     required: false
+  dev-requirements:
+    description: 'boolean if there is an extra for development requirements'
+    required: false
+    default: false
 
 outputs:
   output-table: # id of output
@@ -62,6 +66,7 @@ runs:
         ${{ inputs.cov-threshold-total }} \
         ${{ inputs.async-tests }} \
         ${{ inputs.poetry-version }} \
+        ${{ inputs.dev-requirements }} \
       shell: bash
     - run: |
         echo "SHORT_SHA=`echo ${{github.event.after}} | cut -c1-7`" >> $GITHUB_ENV

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,7 @@
 # $6: cov-threshold-total
 # $7: async-tests
 # $8: poetry-version
+# $9: dev-requirements
 
 
 COV_CONFIG_FILE=.coveragerc
@@ -38,6 +39,9 @@ then
   python -m poetry config virtualenvs.create false
   python -m poetry install
   python -m poetry add $TESTING_TOOLS
+  if [ $9 ] then
+    python -m poetry install --extras 'dev'
+  fi
   python -m poetry shell
 elif [ -f "./Pipfile" ] && [ -f "./Pipfile.lock" ];
 then


### PR DESCRIPTION
Allow for the action to also install dev requirements extra if needed.
Only applied on poetry usage, but could also be used in pip.

Closes #5 